### PR TITLE
Stack Auth UX fixes: dark theme, bare-axios interceptor, Suspense boundary

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark" style="color-scheme: dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/frontend/src/auth/stack.ts
+++ b/frontend/src/auth/stack.ts
@@ -1,4 +1,5 @@
 import { StackClientApp } from '@stackframe/react';
+import axios from 'axios';
 
 const projectId = import.meta.env.VITE_STACK_PROJECT_ID as string | undefined;
 
@@ -18,3 +19,38 @@ export const stackApp = new StackClientApp({
     afterSignOut: '/handler/sign-in',
   },
 });
+
+// Exported so other axios instances (like `api` in services/api.ts) can attach
+// the same logic. Applied to the axios singleton below so every bare
+// `axios.get/post` throughout the app carries the Bearer token automatically.
+export const attachBearer = async (config: any) => {
+  try {
+    const user = await stackApp.getUser();
+    if (user) {
+      const { accessToken } = await user.getAuthJson();
+      if (accessToken) {
+        config.headers = config.headers ?? {};
+        config.headers.Authorization = `Bearer ${accessToken}`;
+      }
+    }
+  } catch {
+    // No session yet — the request will 401 and the response interceptor redirects.
+  }
+  return config;
+};
+
+axios.interceptors.request.use(attachBearer);
+
+axios.interceptors.response.use(
+  (r) => r,
+  (error) => {
+    if (
+      error?.response?.status === 401 &&
+      typeof window !== 'undefined' &&
+      !window.location.pathname.startsWith('/handler/')
+    ) {
+      window.location.href = '/handler/sign-in';
+    }
+    return Promise.reject(error);
+  }
+);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -38,9 +38,17 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
               <Route
                 path="*"
                 element={
-                  <RequireAuth>
-                    <App />
-                  </RequireAuth>
+                  <Suspense
+                    fallback={
+                      <div className="flex h-screen items-center justify-center bg-gray-950 text-gray-100">
+                        <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+                      </div>
+                    }
+                  >
+                    <RequireAuth>
+                      <App />
+                    </RequireAuth>
+                  </Suspense>
                 }
               />
             </Routes>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -160,23 +160,12 @@ const api = axios.create({
   },
 })
 
-// Request interceptor for auth — attach Stack Auth bearer token on every API call.
-import { stackApp } from '../auth/stack'
-
-api.interceptors.request.use(async (config) => {
-  try {
-    const user = await stackApp.getUser()
-    if (user) {
-      const { accessToken } = await user.getAuthJson()
-      if (accessToken) {
-        config.headers.Authorization = `Bearer ${accessToken}`
-      }
-    }
-  } catch {
-    // No session yet — requests to protected endpoints will 401 and trigger redirect.
-  }
-  return config
-})
+// Request/response interceptors for this instance are wired centrally in
+// `src/auth/stack.ts` on the axios singleton, so every caller (including
+// legacy components using bare `axios` imports) gets the Stack Auth bearer.
+// This instance inherits via attaching the same interceptor explicitly.
+import { attachBearer } from '../auth/stack'
+api.interceptors.request.use(attachBearer)
 
 // Enhanced error logging function
 const logError = (error: any) => {


### PR DESCRIPTION
Three bugs spotted once we actually tried the browser flow:

1. **Dark-on-dark sign-in page** — Stack Auth's handler rendered in light mode on our dark background. Fixed by marking \`<html class=\"dark\" style=\"color-scheme: dark\">\`; Stack Auth's BrowserScript detects the signal and flips its CSS.
2. **401 on create-project** — the request interceptor was attached only to the custom \`api\` axios instance; App.tsx (and other legacy callers) use the bare \`axios\` import. Moved interceptor setup to \`auth/stack.ts\` (always loaded at boot) and registered it on the axios singleton AND the custom instance. Added a 401 response interceptor that redirects to \`/handler/sign-in\`.
3. **React error #426** — \`useUser({ or: 'redirect' })\` suspends; without a Suspense ancestor, a synchronous re-render (e.g. clicking a button that calls axios) re-suspended and React bailed. Added \`<Suspense fallback={spinner}>\` above \`<RequireAuth>\`.

Also:
- Dropped the fictitious \`publishableClientKey\` from earlier \u2014 Stack Auth only issues project ID + secret server key.

## Test plan
- [x] Sign-in page renders dark (light text on dark bg)
- [x] Create project from UI returns 200
- [x] No React error #426 on button clicks
- [x] 401 redirects to sign-in

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)