### PR TITLE
deploy: Coolify prod compose + relative API_URL

### DIFF
--- a/.coolify.json
+++ b/.coolify.json
@@ -1,0 +1,36 @@
+{
+  "project_name": "lineary",
+  "deploy_remote": "deploy",
+  "deploy_repo": "git@github.com:21nauts/lineary.git",
+  "github_app_uuid": "yko440cs8cgk488cc4wgw4oc",
+  "resource_type": "docker-compose",
+  "compose_file": "docker-compose.prod.yml",
+  "branch_strategy": {
+    "local": "production",
+    "test": "main",
+    "production": "main"
+  },
+  "apps": {
+    "stack": {
+      "uuid": "",
+      "compose_file": "docker-compose.prod.yml",
+      "domain_prod": "lineary.ai",
+      "healthcheck_path": "/api/health"
+    }
+  },
+  "env_vars": {
+    "stack": {
+      "build_time": [
+        "STACK_PROJECT_ID"
+      ],
+      "runtime": [
+        "POSTGRES_PASSWORD",
+        "JWT_SECRET",
+        "STACK_PROJECT_ID",
+        "STACK_SECRET_SERVER_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY"
+      ]
+    }
+  }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,93 @@
+# Production compose for Coolify deployment.
+# - No host port bindings (Coolify's Traefik handles external routing).
+# - No source bind-mounts (the built image is authoritative).
+# - Frontend is the only service exposed publicly; it proxies /api/ to backend via its own nginx.
+# - Postgres + Redis + backend stay on the internal Coolify-managed network.
+# - Env vars in ${VAR} form are populated by Coolify's env settings.
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-lineary_db}
+      POSTGRES_USER: ${POSTGRES_USER:-lineary}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_INITDB_ARGS: --encoding=UTF-8
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init-db:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-lineary} -d ${POSTGRES_DB:-lineary_db}"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      NODE_ENV: production
+      PORT: 8000
+      DATABASE_URL: postgresql://${POSTGRES_USER:-lineary}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-lineary_db}
+      REDIS_URL: redis://redis:6379
+      JWT_SECRET: ${JWT_SECRET}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      STACK_PROJECT_ID: ${STACK_PROJECT_ID}
+      STACK_SECRET_SERVER_KEY: ${STACK_SECRET_SERVER_KEY}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    expose:
+      - "8000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_STACK_PROJECT_ID: ${STACK_PROJECT_ID}
+    depends_on:
+      - backend
+    expose:
+      - "80"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+    # Traefik labels for Coolify — route lineary.ai to this container on port 80.
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.lineary.rule=Host(`lineary.ai`) || Host(`www.lineary.ai`)"
+      - "traefik.http.routers.lineary.entrypoints=https"
+      - "traefik.http.routers.lineary.tls=true"
+      - "traefik.http.routers.lineary.tls.certresolver=letsencrypt"
+      - "traefik.http.services.lineary.loadbalancer.server.port=80"
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,9 +17,8 @@ import VersionManager from './components/VersionManager'
 import DevelopmentTimeline from './components/DevelopmentTimeline'
 import ProjectColorPicker from './components/ProjectColorPicker'
 
-export const API_URL = window.location.hostname === 'localhost' 
-  ? 'http://localhost:3399/api'
-  : 'https://ai-linear.blockonauts.io/api'
+// Relative: nginx inside the frontend container proxies /api/ to the backend.
+export const API_URL = '/api'
 
 export interface Project {
   id: string


### PR DESCRIPTION
Deploy setup for lineary.ai via Coolify.

- docker-compose.prod.yml for Coolify's Docker Compose resource type
- .coolify.json skill config
- App.tsx API_URL now relative (was pointing at a stale domain)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)