### PR TITLE
ci: auto-mirror production + development to deploy repo

### DIFF
--- a/.github/workflows/mirror-to-deploy.yml
+++ b/.github/workflows/mirror-to-deploy.yml
@@ -1,0 +1,41 @@
+# Mirror production + development branches from the dev repo
+# (48Nauts-Operator/lineary) to the deploy repo (21nauts/lineary).
+# Coolify watches the deploy repo; once this runs, Coolify triggers its
+# own redeploy on the matching branch.
+#
+# Requires the `DEPLOY_MIRROR_TOKEN` secret on this repo — a PAT (fine-
+# grained or classic) with `contents: write` access to 21nauts/lineary.
+
+name: Mirror to deploy
+
+on:
+  push:
+    branches: [production, development]
+  workflow_dispatch:
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token
+        run: |
+          if [ -z "${{ secrets.DEPLOY_MIRROR_TOKEN }}" ]; then
+            echo "::error::DEPLOY_MIRROR_TOKEN secret is missing. Add a PAT with contents:write on 21nauts/lineary."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push to deploy mirror
+        env:
+          TOKEN: ${{ secrets.DEPLOY_MIRROR_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          git config --global user.email "mirror-bot@48nauts.com"
+          git config --global user.name  "lineary-mirror-bot"
+          git remote add deploy "https://x-access-token:${TOKEN}@github.com/21nauts/lineary.git"
+          # Fast-forward when possible; production/development both track 1:1.
+          git push deploy "HEAD:refs/heads/${BRANCH}"
+          echo "Mirrored ${BRANCH} -> 21nauts/lineary:${BRANCH}"


### PR DESCRIPTION
Replaces manual `git push deploy` with a GitHub Action. Needs DEPLOY_MIRROR_TOKEN secret (PAT with contents:write on 21nauts/lineary).